### PR TITLE
Glados fix

### DIFF
--- a/app/GhostDna.php
+++ b/app/GhostDna.php
@@ -27,7 +27,7 @@ class GhostDna extends Model
 
     public function teams()
     {
-        return $this->belongsToMany('App\Team');
+        return $this->belongsToMany('App\Team')->withTimestamps();
     }
 
     /***********************************

--- a/app/Quest.php
+++ b/app/Quest.php
@@ -63,7 +63,7 @@ class Quest extends Model
     }
     public function completedBy()
     {
-        return $this->belongsToMany('App\Team')->registered();
+        return $this->belongsToMany('App\Team')->registered()->withTimestamps();
     }
     public function game()
     {

--- a/app/Question.php
+++ b/app/Question.php
@@ -60,7 +60,7 @@ class Question extends Model
     }
     public function completedBy()
     {
-        return $this->belongsToMany('App\Team');
+        return $this->belongsToMany('App\Team')->withTimestamps();
     }
 
     /***********************************

--- a/database/migrations/2018_01_22_111222_clean_status_tables.php
+++ b/database/migrations/2018_01_22_111222_clean_status_tables.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use App\Team;
+
+class CleanStatusTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $qts = DB::table('quest_team')->get();
+        $timestamp = Carbon::now()->toDateTimeString();
+        foreach($qts as $qt) {
+            if ($qt->created_at !== null) {
+                $timestamp = $qt->created_at;
+            } else {
+                DB::table('quest_team')->where('team_id', $qt->team_id)->where('quest_id', $qt->quest_id)->update([
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp
+                ]);
+            }
+        }
+
+        $teams = Team::all();
+        foreach($teams as $team) {
+            $completedQuests = $team->completedQuests()->get();
+            foreach($completedQuests as $quest) {
+                $completedAt = $quest->pivot->updated_at;
+                $questionIds = $quest->questions->pluck('id');
+                DB::table('question_team')->where('team_id', $team->id)->whereIn('question_id', $questionIds)->where('created_at', null)->update([
+                    'created_at' => $completedAt,
+                    'updated_at' => $completedAt
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2018_01_22_111222_clean_status_tables.php
+++ b/database/migrations/2018_01_22_111222_clean_status_tables.php
@@ -17,7 +17,7 @@ class CleanStatusTables extends Migration
     public function up()
     {
         $qts = DB::table('quest_team')->get();
-        $timestamp = Carbon::now()->toDateTimeString();
+        $timestamp = Carbon::create(2017,10,30,18)->toDateTimeString();
         foreach($qts as $qt) {
             if ($qt->created_at !== null) {
                 $timestamp = $qt->created_at;

--- a/database/migrations/2018_01_22_111222_clean_status_tables.php
+++ b/database/migrations/2018_01_22_111222_clean_status_tables.php
@@ -41,6 +41,11 @@ class CleanStatusTables extends Migration
                 ]);
             }
         }
+
+        DB::table('ghost_dna_team')->where('created_at', null)->update([
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp
+        ]);
     }
 
     /**


### PR DESCRIPTION
'Glados', the game status tracker was failing to display due to NULL timestamps in the database.

The issue was that not all many-to-many model relationships had the `withTimestamps()` modifier.
For example, the following added timestamps when called:
```
$team->completedQuests()->attach($questId);
```
But it's counterpart did not, because the completedBy relationship did not have `withTimestamps()`
```
$quest->completedBy()->attach($teamId);
```

In addition, this fix adds a migration to add timestamps where null values exist. It approximates the timestamp using surrounding timestamps.