### PR TITLE
Fall 2018 updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=
 APP_URL=
-APP_ADMIN_AUTH=adldap
+APP_AUTH=adldap
 PUBLIC_UPLOADS_PATH="storage/uploads"
 
 DB_CONNECTION=mysql

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=
 APP_URL=
+APP_ADMIN_AUTH=adldap
 PUBLIC_UPLOADS_PATH="storage/uploads"
 
 DB_CONNECTION=mysql

--- a/app/Http/Controllers/Admin/GameController.php
+++ b/app/Http/Controllers/Admin/GameController.php
@@ -61,19 +61,12 @@ class GameController extends Controller
             'students_only' => 'required',
         ]);
 
-        $activeGame = Game::active()->get()->first();
-        if(!empty($activeGame)){
-            $activeGame->active = false;
-            $activeGame->save();
-        }
-
         $game = new Game;
         $game->name = $request->get('name');
         $game->start_time = new Carbon($request->get('start_time'));
         $game->end_time = new Carbon($request->get('end_time'));
         $game->max_teams = $request->get('max_teams');
         $game->students_only = $request->get('students_only');
-        $game->active = true;
         $game->save();
 
         $suspects = Suspect::all();

--- a/app/Http/Controllers/Admin/GameController.php
+++ b/app/Http/Controllers/Admin/GameController.php
@@ -184,6 +184,16 @@ class GameController extends Controller
             $request->start_time = date('Y-m-d H:i:s',strtotime($request->start_time));
         }
 
+        // activate the game when opening registration
+        if($request->registration && $request->registration == 1) {
+            $activeGame = Game::active()->get()->first();
+            if(!empty($activeGame)){
+                $activeGame->active = false;
+                $activeGame->save();
+            }
+            $game->active = true;
+        }
+
         foreach($game->getAttributes() as $key => $value){
 
             if(isset($request->{$key}) && $value !== $request->{$key}){

--- a/app/Http/Controllers/UiController.php
+++ b/app/Http/Controllers/UiController.php
@@ -197,6 +197,9 @@ class UiController extends Controller
         $team->suspect()->associate($request->suspect);
         $team->location()->associate($request->location);
         $team->evidence()->associate($request->evidence);
+        if (empty($team->evidence_selected_at)) {
+            $team->evidence_selected_at = Carbon::now()->subSeconds(5);
+        }
         $team->indictment_time = Carbon::now();
 
         $team->save();

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -30,7 +30,7 @@ class WebController extends Controller
 
         $suspects = Suspect::get();
 
-        $game = Game::active()->where('registration','=','1')->orderBy('start_time','desc')->first();
+        $game = Game::active()->orderBy('start_time','desc')->first();
 
         $agents['active'] = Agent::active()->get();
         $agents['retired'] = Agent::retired()->get();
@@ -40,14 +40,20 @@ class WebController extends Controller
         $homepageAlert = $globals ? $globals->message : '';
 
         if($game){
+            // get the special notice message
             $globals = DB::table('globals')->where('key','special_notice')->first();
             $special_notice = $globals ? str_replace('||game_date||',$game->start_time->format('l, F jS'),
+                str_replace('||game_time||',$game->start_time->format('g:i A'), $globals->message))
+                : '';
+            // get the registration_closed message
+            $globals = DB::table('globals')->where('key','registration_closed')->first();
+            $registration_closed = $globals ? str_replace('||game_date||',$game->start_time->format('l, F jS'),
                 str_replace('||game_time||',$game->start_time->format('g:i A'), $globals->message))
                 : '';
         }
 
 
-        return view('web.welcome', compact('suspects','game','agents','games','homepageAlert','special_notice'));
+        return view('web.welcome', compact('suspects','game','agents','games','homepageAlert','special_notice','registration_closed'));
     }
 
     /**

--- a/app/Team.php
+++ b/app/Team.php
@@ -112,7 +112,7 @@ class Team extends Model
         $status[] = [
             'name' => 'Evidence Room',
             'color' => empty($this->evidence_id) ? 'empty' : 'evidence',
-            'time' => empty($this->evidence_id) ? $notSet : $this->evidence_selected_at->format('U'),
+            'time' => empty($this->evidence_selected_at) ? $notSet : $this->evidence_selected_at->format('U'),
         ];
 
         return collect($status);

--- a/app/Team.php
+++ b/app/Team.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Team extends Model
 {
 
+    const MINIMUM_PLAYERS = 4;
     use SoftDeletes;
 
     /***********************************

--- a/config/auth.php
+++ b/config/auth.php
@@ -59,7 +59,7 @@ return [
     | sources which represent each model / table. These sources may then
     | be assigned to any extra authentication guards you have defined.
     |
-    | Supported: "database", "eloquent"
+    | Supported: "database", "eloquent", "adldap"
     |
     */
 
@@ -69,7 +69,7 @@ return [
             'model' => App\Player::class,
         ],
         'admin' => [
-            'driver' => 'adldap',
+            'driver' => env('APP_ADMIN_AUTH', 'adldap'),
             'model' => App\Agent::class,
         ],
     ],

--- a/config/auth.php
+++ b/config/auth.php
@@ -65,11 +65,11 @@ return [
 
     'providers' => [
         'player' => [
-            'driver' => 'adldap',
+            'driver' => env('APP_AUTH', 'adldap'),
             'model' => App\Player::class,
         ],
         'admin' => [
-            'driver' => env('APP_ADMIN_AUTH', 'adldap'),
+            'driver' => env('APP_AUTH', 'adldap'),
             'model' => App\Agent::class,
         ],
     ],

--- a/config/site_messages.php
+++ b/config/site_messages.php
@@ -2,7 +2,7 @@
 
 return [
     'homepage' => [
-        'description' => 'This appears on the homepage just below the jumbotron, above the main navigation when registration is OFF',
+        'description' => 'This appears on the homepage just below the jumbotron, ONLY when all games are DORMANT or ARCHIVED',
         'markdown' => false,
         'vars' => [],
         'rows' => 3
@@ -11,6 +11,15 @@ return [
         'description' => 'This appears on the homepage just below the jumbotron, above the main navigation when registration is ON',
         'markdown' => true,
         'rows' => 7,
+        'vars' => [
+            'game_date' => 'The weekday, month and day of the game',
+            'game_time' => 'The game start time',
+        ]
+    ],
+    'registration_closed' => [
+        'description' => 'This appears on the homepage just below the jumbotron, above the main navigation when registration is OFF and a game is ACTIVE.',
+        'markdown' => true,
+        'rows' => 4,
         'vars' => [
             'game_date' => 'The weekday, month and day of the game',
             'game_time' => 'The game start time',

--- a/database/seeds/FakePlayerSeeder.php
+++ b/database/seeds/FakePlayerSeeder.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Seeder;
 use App\Player;
+use Illuminate\Support\Facades\DB;
 
 class FakePlayerSeeder extends Seeder
 {
@@ -14,9 +15,11 @@ class FakePlayerSeeder extends Seeder
     {
         // Only run this if you're on a local environment
         if(env('APP_ENV') === 'local') {
-            for ($x = 0; $x <= 3000; $x++) {
+            $max_player_id = $users = DB::table('player_team')
+                ->select(DB::raw('max(player_id) as max_player_id'))->first()->max_player_id;
+            for ($x = 0; $x <= $max_player_id; $x++) {
                 $p = new Player;
-                $p->email = str_random(12).'@gmail.com';
+                $p->email = str_random(12).'@fake.fake';
                 $p->first_name = str_random(5);
                 $p->last_name = str_random(8);
                 $p->class_code = array_random(array_keys($p::CLASS_OPTIONS));

--- a/database/seeds/FakePlayerSeeder.php
+++ b/database/seeds/FakePlayerSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Player;
+
+class FakePlayerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Only run this if you're on a local environment
+        if(env('APP_ENV') === 'local') {
+            for ($x = 0; $x <= 3000; $x++) {
+                $p = new Player;
+                $p->email = str_random(12).'@gmail.com';
+                $p->first_name = str_random(5);
+                $p->last_name = str_random(8);
+                $p->class_code = array_random(array_keys($p::CLASS_OPTIONS));
+                $p->academic_group_code = array_random(array_keys($p::ACADEMIC_GROUP_OPTIONS));
+                $p->save();
+            }
+        }
+    }
+}

--- a/database/seeds/LocalAdminSeeder.php
+++ b/database/seeds/LocalAdminSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 use App\Agent;
 
 class LocalAdminSeeder extends Seeder
@@ -18,7 +19,7 @@ class LocalAdminSeeder extends Seeder
             $agent->onyen = 'admin';
             $agent->first_name = 'admin';
             $agent->last_name = 'admin';
-            $agent->password = 'admin';
+            $agent->password = Hash::make('admin');
             $agent->admin = true;
             $agent->save();
         }

--- a/database/seeds/LocalAdminSeeder.php
+++ b/database/seeds/LocalAdminSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Agent;
+
+class LocalAdminSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Only run this if you're on a local environment
+        if(env('APP_ENV') === 'local') {
+            $agent = new Agent;
+            $agent->onyen = 'admin';
+            $agent->first_name = 'admin';
+            $agent->last_name = 'admin';
+            $agent->password = 'admin';
+            $agent->admin = true;
+            $agent->save();
+        }
+    }
+}

--- a/resources/views/admin/siteMessages.blade.php
+++ b/resources/views/admin/siteMessages.blade.php
@@ -10,33 +10,27 @@
             <div class="col-xs-12">
                 @include('admin._alert')
                 <h1>Site Messages</h1>
-                @if(!empty($missing_config_entry))
-                    <p class="lead text-warning">
-                        Warning! The following site messages don't
-                        have configuration files: {{ implode(',',$missing_config_entry) }}
-                    </p>
-                @endif
-                @foreach($messages as $message)
+                @foreach($messages as $key => $message)
                     <div class="row">
                         <div class="col-xs-12">
-                            {!! Form::open(['route' => ['admin.siteMessages.update',$message->key]]) !!}
-                                <h2>{{ title_case(str_replace('_',' ',$message->key)) }}</h2>
-                                <p class="lead">{{ $message->description }}</p>
+                            {!! Form::open(['route' => ['admin.siteMessages.update',$key]]) !!}
+                                <h2>{{ title_case(str_replace('_',' ',$key)) }}</h2>
+                                <p class="lead">{{ $message['description'] }}</p>
 
-                                @if(!empty($message->vars))
+                                @if(!empty($message['vars']))
                                     <span class="help-block">
                                         You can place the following strings within the text and thye will be replaced by the
                                         variable value from the database. Kind of like a shortcode in wordpress.
                                     </span>
                                     <ul class="list-unstyled">
-                                        @foreach($message->vars as $var => $desc)
+                                        @foreach($message['vars'] as $var => $desc)
                                             <li><code>||{{ $var }}||</code> : {{ $desc }}</li>
                                         @endforeach
                                     </ul>
                                 @endif
 
-                                {!! Form::textarea($message->key, $message->message, ['class' => 'form-control', 'rows' => $message->rows]) !!}
-                                @if($message->markdown)
+                                {!! Form::textarea($key, $message['message'], ['class' => 'form-control', 'rows' => $message['rows']]) !!}
+                                @if($message['markdown'])
                                     <span class="help-block">
                                         <small>Use <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">markdown</a> to style the text</small>
                                     </span>

--- a/resources/views/game/_team_table.blade.php
+++ b/resources/views/game/_team_table.blade.php
@@ -15,7 +15,7 @@
             <td>{{ $team->name }}</td>
             <td>{{ $team->dietary }}</td>
             <td>
-                @if(count($team->players) < 3)
+                @if(count($team->players) < $team::MINIMUM_PLAYERS)
                     <div class="text-warning"><span class="fa fa-warning"></span> Not Enough Players</div>
                 @endif
             </td>

--- a/resources/views/game/snapshots/registration.blade.php
+++ b/resources/views/game/snapshots/registration.blade.php
@@ -4,18 +4,16 @@
         <div class="dash-section-header">
             <h3>
                 Teams
-                @if($game->active)
-                    @if($game->registration != 1)
-                        {!! Form::open(['route' => ['admin.game.update', $game->id], 'method' => 'PUT', 'style' => 'display: inline-block;']) !!}
-                        <input type="hidden" name="registration" value="1">
-                        <button type="submit" class="btn btn-success btn-sm">Open Registration</button>
-                        {!! Form::close() !!}
-                    @else
-                        {!! Form::open(['route' => ['admin.game.update', $game->id], 'method' => 'PUT', 'style' => 'display: inline-block;']) !!}
-                        <input type="hidden" name="registration" value="0">
-                        <button type="submit" class="btn btn-danger btn-sm">Close Registration</button>
-                        {!! Form::close() !!}
-                    @endif
+                @if($game->registration != 1)
+                    {!! Form::open(['route' => ['admin.game.update', $game->id], 'method' => 'PUT', 'style' => 'display: inline-block;']) !!}
+                    <input type="hidden" name="registration" value="1">
+                    <button type="submit" class="btn btn-success btn-sm">Open Registration</button>
+                    {!! Form::close() !!}
+                @else
+                    {!! Form::open(['route' => ['admin.game.update', $game->id], 'method' => 'PUT', 'style' => 'display: inline-block;']) !!}
+                    <input type="hidden" name="registration" value="0">
+                    <button type="submit" class="btn btn-danger btn-sm">Close Registration</button>
+                    {!! Form::close() !!}
                 @endif
             </h3>
         </div>

--- a/resources/views/web/_jumbotron.blade.php
+++ b/resources/views/web/_jumbotron.blade.php
@@ -25,6 +25,8 @@
         <div class="row">
             @if($game && $game->registration)
                 @include('web._special_notice')
+            @elseif($game)
+                @include('web._registration_closed')
             @else
                 @include('web._site_alert')
             @endif

--- a/resources/views/web/_registration_closed.blade.php
+++ b/resources/views/web/_registration_closed.blade.php
@@ -1,0 +1,6 @@
+<div class="col-xs-12 text-center" style="margin-bottom: 5em;">
+    <p class="site-alert">{{ $registration_closed }}</p>
+    <p>
+        <a href="{{ route('enlist.teamManagement') }}" class="btn btn-danger">Manage your team</a>
+    </p>
+</div>

--- a/resources/views/web/registration/team_management.blade.php
+++ b/resources/views/web/registration/team_management.blade.php
@@ -47,7 +47,7 @@
                             add their replacement <em>first</em>, then remove the player.
                         </p>
                         <p>
-                            If you won't have 3 players for the game, please contact us so we can find a replacement team.
+                            If you won't have 4 players for the game, please contact us so we can find a replacement team.
                         </p>
                     @endif
                 <hr>

--- a/resources/views/web/registration/team_management.blade.php
+++ b/resources/views/web/registration/team_management.blade.php
@@ -114,7 +114,7 @@
                     <h3>Edit your team information</h3>
                     @if(\Carbon\Carbon::now() < $team->game->start_time->subDays(3))
                         <div class="alert alert-warning">
-                            <i class="fa fa-warning"></i> <small>Your team name and dietary restrictions must be final by {{ $team->game->start_time->subDays(3)->format('l, F jS @ g:i A') }}</small>
+                            <i class="fa fa-warning"></i> <small>Your team name and dietary restrictions must be finalized by {{ $team->game->start_time->subDays(3)->format('l, F jS @ g:i A') }}</small>
                         </div>
                         {!! Form::model($team, ['route' => 'enlist.updateTeam', 'id' => 'editTeamInfo']) !!}
 

--- a/resources/views/web/registration/team_management.blade.php
+++ b/resources/views/web/registration/team_management.blade.php
@@ -112,20 +112,32 @@
             <div class="row">
                 <div class="col-xs-12 col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
                     <h3>Edit your team information</h3>
-                    {!! Form::model($team, ['route' => 'enlist.updateTeam', 'id' => 'editTeamInfo']) !!}
+                    @if(\Carbon\Carbon::now() < $team->game->start_time->subDays(3))
+                        <div class="alert alert-warning">
+                            <i class="fa fa-warning"></i> <small>Your team name and dietary restrictions must be final by {{ $team->game->start_time->subDays(3)->format('l, F jS @ g:i A') }}</small>
+                        </div>
+                        {!! Form::model($team, ['route' => 'enlist.updateTeam', 'id' => 'editTeamInfo']) !!}
 
-                    <div class="form-group">
-                        {!! Form::label('name','Team Name') !!}
-                        {!! Form::text('name', null, ['class' => 'form-control']) !!}
-                    </div>
-                    <div class="form-group">
-                        {!! Form::label('dietary', 'Dietary Restrictions') !!}
-                        {!! Form:: textarea('dietary', null, ['class' => 'form-control', 'rows' => '4']) !!}
-                    </div>
-                    <div class="form-group">
-                        <button type="submit" class="btn btn-primary">Save</button>
-                    </div>
-                    {!! Form::close() !!}
+                        <div class="form-group">
+                            {!! Form::label('name','Team Name') !!}
+                            {!! Form::text('name', null, ['class' => 'form-control']) !!}
+                        </div>
+                        <div class="form-group">
+                            {!! Form::label('dietary', 'Dietary Restrictions') !!}
+                            {!! Form:: textarea('dietary', null, ['class' => 'form-control', 'rows' => '4']) !!}
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </div>
+                        {!! Form::close() !!}
+                    @else
+                        <div class="alert alert-warning">
+                            <i class="fa fa-warning"></i> <small>
+                                Team information cannot be edited at this time. If you need further assistance, contact us at
+                                <a href="mailto:wilsonclue@listserv.unc.edu" class="alert-link">wilsonclue@listserv.unc.edu</a>
+                            </small>
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/web/registration/team_management.blade.php
+++ b/resources/views/web/registration/team_management.blade.php
@@ -47,7 +47,8 @@
                             add their replacement <em>first</em>, then remove the player.
                         </p>
                         <p>
-                            If you won't have 4 players for the game, please contact us so we can find a replacement team.
+                            If you won't have {{ $team::MINIMUM_PLAYERS }} players for the game, please contact us so we can find a replacement team.
+
                         </p>
                     @endif
                 <hr>


### PR DESCRIPTION
@cazzerson I've added more descriptive messaged to most of the commits.

Let me know if you have questions.

Changes:
- Adds Seeders for local development (Admin user and fake player data)
- Move Authorization setting into the .env file. It defaults to 'adldap' (LDAP authentication), so you do not need to update the .env on the staging/production servers
- prevents teams from updating team names 3 days before game
- teams require at least 4 players to be registered
- adds a new site message for when registration closes