### PR TITLE
Allow a storage path to be set in .env

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
         'file' => [
             'driver' => 'file',
-            'path'   => env('STORAGE_PATH', storage_path()).'/framework/cache',
+            'path'   => env('STORAGE_PATH', storage_path()).'/framework/cache/data',
         ],
 
         'memcached' => [

--- a/config/cache.php
+++ b/config/cache.php
@@ -44,7 +44,7 @@ return [
 
         'file' => [
             'driver' => 'file',
-            'path' => storage_path('framework/cache/data'),
+            'path'   => env('STORAGE_PATH', storage_path()).'/framework/cache',
         ],
 
         'memcached' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -45,7 +45,7 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            'root'   => env('STORAGE_PATH', storage_path()).'/app',
         ],
 
         'public' => [

--- a/config/session.php
+++ b/config/session.php
@@ -57,7 +57,7 @@ return [
     |
     */
 
-    'files' => storage_path('framework/sessions'),
+    'files' => env('STORAGE_PATH', storage_path()).'/framework/sessions',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/view.php
+++ b/config/view.php
@@ -28,6 +28,6 @@ return [
     |
     */
 
-    'compiled' => realpath(storage_path('framework/views')),
+    'compiled' => env('STORAGE_PATH', realpath(storage_path())).'/framework/views',
 
 ];


### PR DESCRIPTION
In advance of walnut migration, allow a storage path to be et in .env file.

Added STORAGE_PATH=/opt/laravel/clue to .env files

Deployed and running on QA: https://natchez.lib.unc.edu/clue